### PR TITLE
fix: deepMerge array/null semantics, safe empty-object dispatch, V.!?

### DIFF
--- a/app/JsonLogic.hs
+++ b/app/JsonLogic.hs
@@ -376,7 +376,7 @@ concatValue a b = deepMerge a b
 
 deepMerge :: Value -> Value -> Value
 deepMerge (Object a) (Object b) = Object (AKM.unionWith deepMerge a b)
-deepMerge (Array _) (Array b) = Array b
+deepMerge (Array a) (Array b) = Array (a <> b)
 deepMerge a Null = a
 deepMerge _ b = b
 

--- a/app/JsonLogic.hs
+++ b/app/JsonLogic.hs
@@ -90,11 +90,14 @@ jsonLogic :: (MonadThrow m, MonadCatch m, MonadIO m) => Value -> Value -> m Valu
 jsonLogic tests data_ =
   case tests of
     A.Object dict ->
-      let operator = AK.toString $ fst (head (AKM.toList dict))
-          values = snd (head (AKM.toList dict))
-          eatTheKey = DL.isSuffixOf "'" operator
-          operator' = AK.fromString $ if eatTheKey then DT.unpack $ DT.replace "'" "" (DT.pack operator) else operator
-       in applyOperation' operator' values eatTheKey
+      case AKM.toList dict of
+        [] -> pure A.Null
+        ((k, v) : _) ->
+          let operator = AK.toString k
+              values = v
+              eatTheKey = DL.isSuffixOf "'" operator
+              operator' = AK.fromString $ if eatTheKey then DT.unpack $ DT.replace "'" "" (DT.pack operator) else operator
+           in applyOperation' operator' values eatTheKey
     A.Array rules -> A.Array <$> V.mapM (`jsonLogic` data_) rules
     _ -> pure tests
   where
@@ -118,8 +121,10 @@ jsonLogic tests data_ =
           pure $ A.object [operator .= resolvedValues]
 
 applyOperation :: (MonadThrow m, MonadCatch m, MonadIO m) => Key -> [Value] -> Value -> Bool -> m Value
-applyOperation "var" [A.Number ind] (A.Array arr) _ = pure $ arr V.! (fromMaybe 0 $ toBoundedInteger ind :: Int)
-applyOperation "var" [A.String ind] (A.Array arr) _ = pure $ arr V.! (fromMaybe 0 $ readMaybe (DT.unpack ind) :: Int) -- TODO: make it like getVar to add support for nested arrays being access using 1.1.2
+applyOperation "var" [A.Number ind] (A.Array arr) _ =
+  pure $ fromMaybe A.Null $ arr V.!? (fromMaybe 0 $ toBoundedInteger ind :: Int)
+applyOperation "var" [A.String ind] (A.Array arr) _ =
+  pure $ fromMaybe A.Null $ arr V.!? (fromMaybe 0 $ readMaybe (DT.unpack ind) :: Int)
 applyOperation "var" [A.String ""] data_ _ = pure $ getVar data_ "" data_
 applyOperation "var" [A.String var] data_ _ = pure $ getVar data_ var A.Null
 applyOperation "var" [A.String var, value] data_ _ = pure $ getVar data_ var value
@@ -371,7 +376,8 @@ concatValue a b = deepMerge a b
 
 deepMerge :: Value -> Value -> Value
 deepMerge (Object a) (Object b) = Object (AKM.unionWith deepMerge a b)
-deepMerge (Array a) (Array b) = Array (a <> b)
+deepMerge (Array _) (Array b) = Array b
+deepMerge a Null = a
 deepMerge _ b = b
 
 binaryOpJson :: forall m a. (MonadThrow m, MonadCatch m, MonadIO m) => ToJSON a => (Value -> Value -> m a) -> [Value] -> m Value


### PR DESCRIPTION
## Summary

Three targeted fixes for bugs that caused `driver_pool_config_dynamic_logic_failure` alerts in the nammayatri backend.

### Bug 1 — `deepMerge` array concatenation

**`deepMerge (Array a) (Array b) = Array (a <> b)`**

When a JsonLogic rule used `{"var":"config"}` as an `if` else-branch, the `cat` operator deepMerged the `DriverPoolConfig` with itself. Any array-typed field was doubled — specifically `area.contents` went from `["uuid", null]` to `["uuid", null, "uuid", null]` after the `Pickup` constructor was changed from 1 to 2 fields. `fromJSON` then failed: **"expected Array of length 2, encountered Array of length 4"**.

**Fix:** Last-wins (`Array b`) instead of concatenation (`a <> b`).

### Bug 2 — `deepMerge` null propagation

**`deepMerge _ Null = Null`**

Rules with a 2-arg `if` (no explicit else) return `Null` when the condition is false. `deepMerge(baseConfig, Null) = Null` wiped the entire config object, causing: **"expected Object, but encountered Null"**.

**Fix:** `Null` is a no-op — return `a` instead of `b` when `b` is `Null`.

### Bug 3 — `head []` crash on empty JSON objects

**`let operator = AK.toString $ fst (head (AKM.toList dict))`**

`jsonLogicValues` eagerly evaluates **all** `if` arguments including the else-branch. So `{"if": [cond, then, {}]}` called `jsonLogic {} data_` → `head (AKM.toList {})` = `head []` → uncaught Haskell exception → **INTERNAL_ERROR with null message** from the verify API.

**Fix:** `case AKM.toList dict of [] -> pure A.Null; ((k, v) : _) -> ...` — empty objects return `A.Null` safely.

### Fix 4 — `V.!` unsafe array indexing

`applyOperation "var" [Number/String ind] (Array arr)` used `V.!` which panics on out-of-range indices. **Fix:** `V.!?` with `fromMaybe A.Null`.

---

## Changes

Only `app/JsonLogic.hs` is modified. All other library code is unchanged.

| Location | Change |
|----------|--------|
| `deepMerge` | `Array (a <> b)` → `Array b`; add `deepMerge a Null = a` before catch-all |
| `jsonLogic` `A.Object` branch | `head (AKM.toList dict)` → `case AKM.toList dict of [] -> pure A.Null; ((k,v):_) -> ...` |
| `applyOperation "var" [Number/String] (Array)` | `V.!` → `V.!?` with `fromMaybe A.Null` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)